### PR TITLE
Fix overlapping issue when displaying the badge row component

### DIFF
--- a/src/BadgeRow/badge-row.scss
+++ b/src/BadgeRow/badge-row.scss
@@ -11,5 +11,6 @@
     margin-left: -20px;
     border: 2px solid white;
     box-sizing: border-box;
+    z-index: 1;
   }
 }


### PR DESCRIPTION
On some browsers the overlapping of the badges within a badge row component differs, adding a z-index style seems to bring these inline so they display correctly.